### PR TITLE
fix: mobile responsive – navbar hamburger, hero stats, grid breakpoints

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -16,6 +16,10 @@ const Section = styled.section`
   padding: 80px 24px 100px;
   text-align: center;
 
+  @media (max-width: 768px) {
+    padding: 48px 20px 60px;
+  }
+
   &::before {
     content: "";
     position: absolute;
@@ -76,6 +80,15 @@ const Buttons = styled.div`
   gap: 12px;
   flex-wrap: wrap;
   margin-bottom: 64px;
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    max-width: 320px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 `;
 
 const BtnPrimary = styled(Link)`
@@ -95,6 +108,10 @@ const BtnPrimary = styled(Link)`
     background: ${theme.colors.primaryHover};
     box-shadow: 0 0 30px rgba(124, 106, 255, 0.4);
     transform: translateY(-1px);
+  }
+
+  @media (max-width: 480px) {
+    justify-content: center;
   }
 `;
 
@@ -116,6 +133,10 @@ const BtnSecondary = styled(Link)`
     border-color: ${theme.colors.borderLight};
     background: ${theme.colors.bgHover};
   }
+
+  @media (max-width: 480px) {
+    justify-content: center;
+  }
 `;
 
 const Stats = styled.div`
@@ -124,6 +145,10 @@ const Stats = styled.div`
   justify-content: center;
   gap: 40px;
   flex-wrap: wrap;
+
+  @media (max-width: 480px) {
+    gap: 24px;
+  }
 `;
 
 const Stat = styled.div`
@@ -135,6 +160,10 @@ const Stat = styled.div`
     font-weight: 800;
     color: ${theme.colors.text};
     letter-spacing: -0.5px;
+
+    @media (max-width: 480px) {
+      font-size: 22px;
+    }
   }
 
   span {
@@ -147,6 +176,10 @@ const Divider = styled.div`
   width: 1px;
   height: 36px;
   background: ${theme.colors.border};
+
+  @media (max-width: 480px) {
+    display: none;
+  }
 `;
 
 export default function Hero() {

--- a/src/components/home/PartyPreview.tsx
+++ b/src/components/home/PartyPreview.tsx
@@ -72,6 +72,10 @@ const Section = styled.section`
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px 80px;
+
+  @media (max-width: 768px) {
+    padding: 0 16px 60px;
+  }
 `;
 
 const Header = styled.div`
@@ -120,8 +124,13 @@ const ViewAll = styled(Link)`
 
 const Grid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 16px;
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
 `;
 
 export default function PartyPreview() {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import styled from "styled-components";
 import { theme } from "@/styles/theme";
-import { Gamepad2, LogIn } from "lucide-react";
+import { Gamepad2, LogIn, Menu, X } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
 
 const Nav = styled.nav`
   position: sticky;
@@ -45,6 +46,10 @@ const NavLinks = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const NavLink = styled(Link)`
@@ -75,11 +80,103 @@ const LoginBtn = styled(Link)`
   &:hover {
     background: ${theme.colors.primaryHover};
   }
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
+
+const HamburgerBtn = styled.button`
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: 1px solid ${theme.colors.border};
+  border-radius: ${theme.radii.sm};
+  color: ${theme.colors.text};
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${theme.colors.bgHover};
+  }
+
+  @media (max-width: 768px) {
+    display: flex;
+  }
+`;
+
+const MobileMenu = styled.div<{ $open: boolean }>`
+  display: none;
+
+  @media (max-width: 768px) {
+    display: ${({ $open }) => ($open ? "flex" : "none")};
+    flex-direction: column;
+    position: absolute;
+    top: 60px;
+    left: 0;
+    right: 0;
+    background: rgba(13, 15, 20, 0.97);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid ${theme.colors.border};
+    padding: 12px 16px 16px;
+    gap: 4px;
+    z-index: 99;
+  }
+`;
+
+const MobileNavLink = styled(Link)`
+  padding: 10px 14px;
+  border-radius: ${theme.radii.sm};
+  font-size: 15px;
+  color: ${theme.colors.textMuted};
+  transition: all 0.15s;
+
+  &:hover {
+    color: ${theme.colors.text};
+    background: ${theme.colors.bgHover};
+  }
+`;
+
+const MobileLoginBtn = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 16px;
+  margin-top: 8px;
+  border-radius: ${theme.radii.sm};
+  font-size: 14px;
+  font-weight: 600;
+  background: ${theme.colors.primary};
+  color: #fff;
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${theme.colors.primaryHover};
+  }
 `;
 
 export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
   return (
-    <Nav>
+    <Nav ref={menuRef}>
       <Inner>
         <Logo href="/">
           <Gamepad2 size={20} />
@@ -96,7 +193,21 @@ export default function Navbar() {
           <LogIn size={15} />
           เข้าสู่ระบบ
         </LoginBtn>
+
+        <HamburgerBtn onClick={() => setOpen((v) => !v)} aria-label="Toggle menu">
+          {open ? <X size={18} /> : <Menu size={18} />}
+        </HamburgerBtn>
       </Inner>
+
+      <MobileMenu $open={open}>
+        <MobileNavLink href="/parties" onClick={() => setOpen(false)}>หาปาร์ตี้</MobileNavLink>
+        <MobileNavLink href="/games" onClick={() => setOpen(false)}>เกม</MobileNavLink>
+        <MobileNavLink href="/leaderboard" onClick={() => setOpen(false)}>อันดับ</MobileNavLink>
+        <MobileLoginBtn href="/auth/signin" onClick={() => setOpen(false)}>
+          <LogIn size={15} />
+          เข้าสู่ระบบ
+        </MobileLoginBtn>
+      </MobileMenu>
     </Nav>
   );
 }

--- a/src/components/party/PartyCard.tsx
+++ b/src/components/party/PartyCard.tsx
@@ -24,6 +24,10 @@ const Card = styled(Link)`
     transform: translateY(-2px);
     box-shadow: ${theme.shadows.glow};
   }
+
+  @media (max-width: 480px) {
+    padding: 16px;
+  }
 `;
 
 const Top = styled.div`
@@ -93,7 +97,8 @@ const Footer = styled.div`
 const Meta = styled.div`
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
+  flex-wrap: wrap;
 `;
 
 const MetaItem = styled.span`


### PR DESCRIPTION
## Summary
- Added hamburger menu to Navbar (hidden on desktop, toggles MobileMenu dropdown on mobile)
- Fixed Hero stats layout – hide vertical dividers and reduce gap at < 480px
- CTA buttons stack vertically and go full-width on mobile
- PartyPreview grid collapses to single column at < 480px
- PartyCard Meta items wrap instead of overflow on small cards

## Test plan
- [ ] Open http://localhost:3000 and resize to 480px width
- [ ] Verify hamburger menu opens/closes correctly
- [ ] Verify stats display without broken dividers on mobile
- [ ] Verify party cards stack to 1 column on small screens
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with Claude Code